### PR TITLE
[Week 7] JPA 연결하기

### DIFF
--- a/src/main/java/kr/megaptera/assignment/application/CreateCommentService.java
+++ b/src/main/java/kr/megaptera/assignment/application/CreateCommentService.java
@@ -1,0 +1,36 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CreateCommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    public CreateCommentService(PostRepository postRepository, CommentRepository commentRepository) {
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+    }
+
+    public CommentDto createComment(String postId, CommentCreateDto commentCreateDto) {
+
+        Optional<Post> check = postRepository.findById(PostId.of(postId));
+        if (check.isEmpty()) {
+            throw new PostNotFound();
+        }
+        Comment comment = new Comment(check.get(), commentCreateDto);
+        commentRepository.save(comment);
+        return new CommentDto(comment);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/CreatePostService.java
+++ b/src/main/java/kr/megaptera/assignment/application/CreatePostService.java
@@ -1,0 +1,23 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreatePostService {
+
+    private final PostRepository postRepository;
+
+    public CreatePostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public PostDto createPost(PostCreateDto postCreateDto) {
+        Post post = new Post(postCreateDto);
+        postRepository.save(new Post(postCreateDto));
+        return new PostDto(post);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/DeleteCommentService.java
+++ b/src/main/java/kr/megaptera/assignment/application/DeleteCommentService.java
@@ -1,0 +1,29 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.exceptions.CommentNotFound;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class DeleteCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public DeleteCommentService(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    public CommentDto deleteComment(String id) {
+        Optional<Comment> check = commentRepository.findById(CommentId.of(id));
+        if (check.isEmpty())
+            throw new CommentNotFound();
+        Comment comment = check.get();
+        commentRepository.delete(comment);
+        return new CommentDto(comment);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/DeletePostService.java
+++ b/src/main/java/kr/megaptera/assignment/application/DeletePostService.java
@@ -1,0 +1,30 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class DeletePostService {
+
+    private final PostRepository postRepository;
+
+    public DeletePostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public PostDto deletePost(String id) {
+        Optional<Post> check = postRepository.findById(PostId.of(id));
+        if (check.isEmpty())
+            throw new PostNotFound();
+
+        Post post = check.get();
+        postRepository.delete(post);
+        return new PostDto(post);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/GetCommentsService.java
+++ b/src/main/java/kr/megaptera/assignment/application/GetCommentsService.java
@@ -1,0 +1,23 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GetCommentsService {
+
+    private final CommentRepository commentRepository;
+
+    public GetCommentsService(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    public List<CommentDto> getComments(String postId) {
+        return commentRepository.findByPostId(PostId.of(postId))
+                .stream().map(CommentDto::new).toList();
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/GetPostService.java
+++ b/src/main/java/kr/megaptera/assignment/application/GetPostService.java
@@ -1,0 +1,27 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class GetPostService {
+
+    private final PostRepository postRepository;
+
+    public GetPostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public PostDto getPost(String id) {
+        Optional<Post> check = postRepository.findById(PostId.of(id));
+        if (check.isEmpty())
+            throw new PostNotFound();
+        return new PostDto(check.get());
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/GetPostsService.java
+++ b/src/main/java/kr/megaptera/assignment/application/GetPostsService.java
@@ -1,0 +1,22 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GetPostsService {
+
+    private final PostRepository postRepository;
+
+    public GetPostsService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public List<PostDto> getPosts() {
+        return postRepository.findAll()
+                .stream().map(PostDto::new).toList();
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/UpdateCommentService.java
+++ b/src/main/java/kr/megaptera/assignment/application/UpdateCommentService.java
@@ -1,0 +1,31 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.exceptions.CommentNotFound;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UpdateCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public UpdateCommentService(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    public CommentDto updateComment(String id, String postId, CommentUpdateDto commentUpdateDto) {
+        Optional<Comment> check = commentRepository.findById(CommentId.of(id));
+        if (check.isEmpty())
+            throw new CommentNotFound();
+        Comment comment = check.get();
+        comment.updateComment(commentUpdateDto);
+        commentRepository.save(comment);
+        return new CommentDto(comment);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/application/UpdatePostService.java
+++ b/src/main/java/kr/megaptera/assignment/application/UpdatePostService.java
@@ -1,0 +1,34 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UpdatePostService {
+
+    private final PostRepository postRepository;
+
+    public UpdatePostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public PostDto updatePost(String id, PostUpdateDto postUpdateDto) {
+        Optional<Post> check = postRepository.findById(PostId.of(id));
+
+        if (check.isEmpty())
+            throw new PostNotFound();
+
+        Post post = check.get();
+
+        post.updatePost(postUpdateDto);
+        postRepository.save(post);
+        return new PostDto(post);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/config/CorsConfig.java
+++ b/src/main/java/kr/megaptera/assignment/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package kr.megaptera.assignment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://127.0.0.1:8000")
+                .allowedOrigins("http://localhost:8000")
+                .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE");
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/controllers/CommentController.java
+++ b/src/main/java/kr/megaptera/assignment/controllers/CommentController.java
@@ -1,0 +1,80 @@
+package kr.megaptera.assignment.controllers;
+
+import kr.megaptera.assignment.application.CreateCommentService;
+import kr.megaptera.assignment.application.DeleteCommentService;
+import kr.megaptera.assignment.application.GetCommentsService;
+import kr.megaptera.assignment.application.UpdateCommentService;
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+import kr.megaptera.assignment.exceptions.CommentNotFound;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/comments")
+@RestController
+public class CommentController {
+
+    private final GetCommentsService getCommentsService;
+    private final CreateCommentService createCommentService;
+    private final UpdateCommentService updateCommentService;
+    private final DeleteCommentService deleteCommentService;
+
+    public CommentController(GetCommentsService getCommentsService, CreateCommentService createCommentService,
+                             UpdateCommentService updateCommentService, DeleteCommentService deleteCommentService) {
+        this.getCommentsService = getCommentsService;
+        this.createCommentService = createCommentService;
+        this.updateCommentService = updateCommentService;
+        this.deleteCommentService = deleteCommentService;
+    }
+
+    @GetMapping
+    public List<CommentDto> list(
+            @RequestParam("postId") String postId
+    ) {
+        return getCommentsService.getComments(postId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentDto create(
+            @RequestParam("postId") String postId,
+            @RequestBody CommentCreateDto commentCreateDto
+    ) {
+        return createCommentService.createComment(postId, commentCreateDto);
+    }
+
+    @PatchMapping("/{id}")
+    public CommentDto update(
+            @PathVariable String id,
+            @RequestParam("postId") String postId,
+            @RequestBody CommentUpdateDto commentUpdateDto
+    ) {
+        return updateCommentService.updateComment(id, postId, commentUpdateDto);
+    }
+
+    @DeleteMapping("/{id}")
+    public CommentDto delete(
+            @PathVariable String id
+    ) {
+        return deleteCommentService.deleteComment(id);
+    }
+
+    @ExceptionHandler(CommentNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String commentNotFound() {
+        return "There's no comment you want to see.\n";
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/assignment/controllers/PostController.java
@@ -1,0 +1,86 @@
+package kr.megaptera.assignment.controllers;
+
+import kr.megaptera.assignment.application.CreatePostService;
+import kr.megaptera.assignment.application.DeletePostService;
+import kr.megaptera.assignment.application.GetPostService;
+import kr.megaptera.assignment.application.GetPostsService;
+import kr.megaptera.assignment.application.UpdatePostService;
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/posts")
+@RestController
+public class PostController {
+
+    private final GetPostService getPostService;
+    private final GetPostsService getPostsService;
+    private final CreatePostService createPostService;
+    private final UpdatePostService updatePostService;
+    private final DeletePostService deletePostService;
+
+    public PostController(GetPostService getPostService, GetPostsService getPostsService,
+                          CreatePostService createPostService, UpdatePostService updatePostService,
+                          DeletePostService deletePostService) {
+        this.getPostService = getPostService;
+        this.getPostsService = getPostsService;
+        this.createPostService = createPostService;
+        this.updatePostService = updatePostService;
+        this.deletePostService = deletePostService;
+    }
+
+    @GetMapping
+    public List<PostDto> list() {
+        return getPostsService.getPosts();
+    }
+
+    @GetMapping("/{id}")
+    public PostDto detail(
+            @PathVariable String id
+    ) {
+        return getPostService.getPost(id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PostDto create(
+            @RequestBody PostCreateDto postCreateDto
+    ) {
+        return createPostService.createPost(postCreateDto);
+    }
+
+    @PatchMapping("/{id}")
+    public PostDto update(
+            @RequestBody PostUpdateDto postUpdateDto,
+            @PathVariable String id
+    ) {
+        return updatePostService.updatePost(id, postUpdateDto);
+    }
+
+    @DeleteMapping("/{id}")
+    public PostDto delete(
+            @PathVariable String id
+    ) {
+        return deletePostService.deletePost(id);
+    }
+
+    @ExceptionHandler(PostNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String postNotFound() {
+        return "There's no post you want to see.\n";
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/dto/CommentCreateDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/CommentCreateDto.java
@@ -1,0 +1,24 @@
+package kr.megaptera.assignment.domains.dto;
+
+public class CommentCreateDto {
+
+    private String author;
+    private String content;
+
+    public CommentCreateDto() {
+    }
+
+    public CommentCreateDto(String author, String content) {
+        this.author = author;
+        this.content = content;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}
+

--- a/src/main/java/kr/megaptera/assignment/domains/dto/CommentDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/CommentDto.java
@@ -1,0 +1,39 @@
+package kr.megaptera.assignment.domains.dto;
+
+import kr.megaptera.assignment.domains.model.Comment;
+
+public class CommentDto {
+
+    private String id;
+
+    private String author;
+
+    private String content;
+
+    public CommentDto() {
+    }
+
+    public CommentDto(String id, String author, String content) {
+        this.id = id;
+        this.author = author;
+        this.content = content;
+    }
+
+    public CommentDto(Comment comment) {
+        this.id = comment.id().getId();
+        this.author = comment.author().getAuthor();
+        this.content = comment.content().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/dto/CommentUpdateDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/CommentUpdateDto.java
@@ -1,0 +1,17 @@
+package kr.megaptera.assignment.domains.dto;
+
+public class CommentUpdateDto {
+
+    private String content;
+
+    public CommentUpdateDto() {
+    }
+
+    public CommentUpdateDto(String content) {
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/dto/PostCreateDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/PostCreateDto.java
@@ -1,0 +1,29 @@
+package kr.megaptera.assignment.domains.dto;
+
+public class PostCreateDto {
+
+    private String title;
+    private String author;
+    private String content;
+
+    public PostCreateDto() {
+    }
+
+    public PostCreateDto(String title, String author, String content) {
+        this.title = title;
+        this.author = author;
+        this.content = content;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/dto/PostDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/PostDto.java
@@ -1,0 +1,46 @@
+package kr.megaptera.assignment.domains.dto;
+
+import kr.megaptera.assignment.domains.model.Post;
+
+public class PostDto {
+    private String id;
+
+    private String title;
+
+    private String author;
+
+    private String content;
+
+    public PostDto() {
+    }
+
+    public PostDto(String id, String title, String author, String content) {
+        this.id = id;
+        this.title = title;
+        this.author = author;
+        this.content = content;
+    }
+
+    public PostDto(Post post) {
+        this.id = post.id().getId();
+        this.content = post.content().toString();
+        this.author = post.author().getAuthor();
+        this.title = post.title().getTitle();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/dto/PostUpdateDto.java
+++ b/src/main/java/kr/megaptera/assignment/domains/dto/PostUpdateDto.java
@@ -1,0 +1,23 @@
+package kr.megaptera.assignment.domains.dto;
+
+public class PostUpdateDto {
+
+    private String title;
+    private String content;
+
+    public PostUpdateDto() {
+    }
+
+    public PostUpdateDto(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/Comment.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/Comment.java
@@ -1,0 +1,63 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+
+@Entity
+public class Comment {
+
+    @EmbeddedId
+    private CommentId id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    private Post post;
+
+    @Embedded
+    private CommentAuthor author;
+
+    @Embedded
+    private MultilineText content;
+
+    private Comment() {
+    }
+
+    public Comment(CommentId id, Post post, CommentAuthor author, MultilineText content) {
+        this.id = id;
+        this.post = post;
+        this.author = author;
+        this.content = content;
+    }
+
+    public Comment(Post post, CommentCreateDto commentCreateDto) {
+        this.id = new CommentId();
+        this.post = post;
+        this.author = CommentAuthor.of(commentCreateDto.getAuthor());
+        this.content = MultilineText.of(commentCreateDto.getContent());
+    }
+
+    public CommentId id() {
+        return this.id;
+    }
+
+    public Post post() {
+        return this.post;
+    }
+
+    public CommentAuthor author() {
+        return this.author;
+    }
+
+    public MultilineText content() {
+        return this.content;
+    }
+
+    public void updateComment(CommentUpdateDto commentUpdateDto) {
+        this.content = MultilineText.of(commentUpdateDto.getContent());
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/CommentAuthor.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/CommentAuthor.java
@@ -1,0 +1,26 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class CommentAuthor {
+
+    @Column
+    private String author;
+
+    private CommentAuthor() {
+    }
+
+    public CommentAuthor(String author) {
+        this.author = author;
+    }
+
+    public static CommentAuthor of(String author) {
+        return new CommentAuthor(author);
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/CommentId.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/CommentId.java
@@ -1,0 +1,47 @@
+package kr.megaptera.assignment.domains.model;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class CommentId implements Serializable {
+
+    @Column(insertable = false, updatable = false)
+    private String id;
+
+    public CommentId() {
+        this.id = generate();
+    }
+
+    public CommentId(String id) {
+        this.id = id;
+    }
+
+    public static CommentId of(String id) {
+        return new CommentId(id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String generate() {
+        return TsidCreator.getTsid().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CommentId commentId)) return false;
+        return Objects.equals(id, commentId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/MultilineText.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/MultilineText.java
@@ -1,0 +1,60 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Embeddable
+public class MultilineText {
+
+    @Column
+    private List<String> content;
+
+    public MultilineText(String text) {
+        // StringTokenizer로 나누면 빈칸을 버려버리는듯
+        this.content = new ArrayList<>(
+                Arrays.stream(text.split("\n"))
+                        .toList());
+    }
+
+    private MultilineText() {
+        this.content = null;
+    }
+
+    ;
+
+    public static MultilineText of(String content) {
+        return new MultilineText(content);
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+
+        for (String line : content) {
+            sb.append(line).append("\n");
+        }
+
+        return sb.toString().trim();
+    }
+
+    public List<String> getContent() {
+        return content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MultilineText that)) return false;
+        return Objects.equals(content, that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/Post.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/Post.java
@@ -1,0 +1,61 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+
+@Entity
+public class Post {
+
+    @EmbeddedId
+    private PostId id;
+
+    @Embedded
+    private PostTitle title;
+
+    @Embedded
+    private PostAuthor author;
+
+    @Embedded
+    private MultilineText content;
+
+    public PostId id() {
+        return id;
+    }
+
+    public PostTitle title() {
+        return title;
+    }
+
+    public PostAuthor author() {
+        return author;
+    }
+
+    public MultilineText content() {
+        return content;
+    }
+
+    public Post() {
+    }
+
+    public Post(PostId postId, PostTitle title, PostAuthor author, MultilineText content) {
+        this.id = postId;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+    }
+
+    public Post(PostCreateDto postCreateDto) {
+        this.id = new PostId();
+        this.author = PostAuthor.of(postCreateDto.getAuthor());
+        this.title = PostTitle.of(postCreateDto.getTitle());
+        this.content = MultilineText.of(postCreateDto.getContent());
+    }
+
+    public void updatePost(PostUpdateDto postUpdateDto) {
+        this.title = PostTitle.of(postUpdateDto.getTitle());
+        this.content = MultilineText.of(postUpdateDto.getContent());
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/PostAuthor.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/PostAuthor.java
@@ -1,0 +1,40 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+@Embeddable
+public class PostAuthor {
+
+    @Column
+    private String author;
+
+    private PostAuthor() {
+    }
+
+    public PostAuthor(String author) {
+        this.author = author;
+    }
+
+    public static PostAuthor of(String author) {
+        return new PostAuthor(author);
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PostAuthor that)) return false;
+        return Objects.equals(author, that.author);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(author);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/PostId.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/PostId.java
@@ -1,0 +1,47 @@
+package kr.megaptera.assignment.domains.model;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class PostId implements Serializable {
+
+    @Column(insertable = false, updatable = false)
+    private String id;
+
+    public PostId() {
+        this.id = generate();
+    }
+
+    public PostId(String id) {
+        this.id = id;
+    }
+
+    public static PostId of(String id) {
+        return new PostId(id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String generate() {
+        return TsidCreator.getTsid().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PostId postId)) return false;
+        return Objects.equals(id, postId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/domains/model/PostTitle.java
+++ b/src/main/java/kr/megaptera/assignment/domains/model/PostTitle.java
@@ -1,0 +1,40 @@
+package kr.megaptera.assignment.domains.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+@Embeddable
+public class PostTitle {
+
+    @Column
+    String title;
+
+    public PostTitle(String title) {
+        this.title = title;
+    }
+
+    private PostTitle() {
+    }
+
+    public static PostTitle of(String title) {
+        return new PostTitle(title);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PostTitle postTitle)) return false;
+        return Objects.equals(title, postTitle.title);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title);
+    }
+}

--- a/src/main/java/kr/megaptera/assignment/exceptions/CommentNotFound.java
+++ b/src/main/java/kr/megaptera/assignment/exceptions/CommentNotFound.java
@@ -1,0 +1,4 @@
+package kr.megaptera.assignment.exceptions;
+
+public class CommentNotFound extends RuntimeException {
+}

--- a/src/main/java/kr/megaptera/assignment/exceptions/PostNotFound.java
+++ b/src/main/java/kr/megaptera/assignment/exceptions/PostNotFound.java
@@ -1,0 +1,4 @@
+package kr.megaptera.assignment.exceptions;
+
+public class PostNotFound extends RuntimeException {
+}

--- a/src/main/java/kr/megaptera/assignment/repositories/CommentRepository.java
+++ b/src/main/java/kr/megaptera/assignment/repositories/CommentRepository.java
@@ -1,4 +1,15 @@
 package kr.megaptera.assignment.repositories;
 
-public interface CommentRepository{
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.domains.model.PostId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, CommentId> {
+
+    List<Comment> findByPostId(PostId postId);
 }

--- a/src/main/java/kr/megaptera/assignment/repositories/PostRepository.java
+++ b/src/main/java/kr/megaptera/assignment/repositories/PostRepository.java
@@ -1,5 +1,11 @@
 package kr.megaptera.assignment.repositories;
 
-public interface PostRepository {
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, PostId> {
     // TODO: JPA 이용해서 과제를 완성해 주세요.
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 # 아래에 데이터베이스를 세팅해주세요. (포트 번호에 주의해주세요)
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
+    url: jdbc:postgresql://localhost:15432/jpademo
+    username: devroad
     password: password
   jpa:
     hibernate:

--- a/src/test/java/kr/megaptera/assignment/application/CreateCommentServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/CreateCommentServiceTest.java
@@ -1,0 +1,55 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class CreateCommentServiceTest {
+
+    private PostRepository postRepository;
+    private CommentRepository commentRepository;
+
+    private CreateCommentService createCommentService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        commentRepository = mock(CommentRepository.class);
+        createCommentService = new CreateCommentService(postRepository, commentRepository);
+    }
+
+    @Test
+    @DisplayName("게시물에 댓글 생성")
+    void createComment() {
+        given(postRepository.findById(PostId.of("1")))
+                .willReturn(
+                        Optional.of(new Post(
+                                PostId.of("1"),
+                                PostTitle.of("내가 첫 글???"),
+                                PostAuthor.of("김종희"),
+                                MultilineText.of("신난닷!!\n너무 좋아용~~!!"))));
+        CommentCreateDto commentCreateDto = new CommentCreateDto("운영자", "감사합니다. 앞으로 자주 이용해 주세요.");
+        createCommentService.createComment("1", commentCreateDto);
+
+        verify(commentRepository).save(any(Comment.class));
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/application/CreatePostServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/CreatePostServiceTest.java
@@ -1,0 +1,36 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class CreatePostServiceTest {
+
+    private PostRepository postRepository;
+
+    private CreatePostService createPostService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        createPostService = new CreatePostService(postRepository);
+    }
+
+    @Test
+    @DisplayName("게시물 생성")
+    void create() {
+        PostCreateDto postCreateDto = new PostCreateDto("새로 글 쓰기", "케이", "새로 글을\n쓰는 중입니다.\n\n좋아용");
+        createPostService.createPost(postCreateDto);
+
+        verify(postRepository).save(any(Post.class));
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/application/DeleteCommentServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/DeleteCommentServiceTest.java
@@ -1,0 +1,66 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentAuthor;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.exceptions.CommentNotFound;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class DeleteCommentServiceTest {
+
+    private CommentRepository commentRepository;
+
+    private DeleteCommentService deleteCommentService;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        deleteCommentService = new DeleteCommentService(commentRepository);
+    }
+
+    @Test
+    @DisplayName("게시물에 이미 존재하는 댓글 삭제")
+    void delete() {
+        given(commentRepository.findById(CommentId.of("3")))
+                .willReturn(
+                        Optional.of(new Comment(
+                                CommentId.of("3"),
+                                new Post(
+                                        PostId.of("1"),
+                                        PostTitle.of("원글"),
+                                        PostAuthor.of("원글쓴이"),
+                                        MultilineText.of("원글 내용")),
+                                CommentAuthor.of("케이"),
+                                MultilineText.of("감사합니다!\n운영자님")
+                        ))
+                );
+
+        CommentDto commentDto = deleteCommentService.deleteComment("3");
+
+        verify(commentRepository).delete(any(Comment.class));
+
+        assertThat(commentDto.getContent()).contains("운영자님");
+        assertThrows(CommentNotFound.class, () -> deleteCommentService.deleteComment("4"));
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/application/DeletePostServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/DeletePostServiceTest.java
@@ -1,0 +1,55 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class DeletePostServiceTest {
+
+    private PostRepository postRepository;
+
+    private DeletePostService deletePostService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        deletePostService = new DeletePostService(postRepository);
+    }
+
+    @Test
+    @DisplayName("게시물 삭제")
+    void delete() {
+        given(postRepository.findById(PostId.of("2")))
+                .willReturn(
+                        Optional.of(new Post(
+                                PostId.of("2"),
+                                PostTitle.of("내가 첫 글???"),
+                                PostAuthor.of("김종희"),
+                                MultilineText.of("신난닷!!\n너무 좋아용~~!!"))));
+
+        PostDto postDto = deletePostService.deletePost("2");
+
+        verify(postRepository).delete(any(Post.class));
+        assertThat(postDto).isNotNull();
+        assertThrows(PostNotFound.class, () -> deletePostService.deletePost("3"));
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/application/GetCommentsServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/GetCommentsServiceTest.java
@@ -1,0 +1,71 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentAuthor;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetCommentsServiceTest {
+
+    private CommentRepository commentRepository;
+
+    private GetCommentsService getCommentsService;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        getCommentsService = new GetCommentsService(commentRepository);
+    }
+
+    @Test
+    @DisplayName("게시물별 댓글 목록 조회")
+    void listByPost() {
+        given(commentRepository.findByPostId(PostId.of("1")))
+                .willReturn(
+                        List.of(
+                                new Comment(
+                                        CommentId.of("1"),
+                                        new Post(
+                                                PostId.of("1"),
+                                                PostTitle.of("원글"),
+                                                PostAuthor.of("원글쓴이"),
+                                                MultilineText.of("원글 내용")),
+                                        CommentAuthor.of("케이"),
+                                        MultilineText.of("감사합니다!\n운영자님")
+                                ),
+                                new Comment(
+                                        CommentId.of("2"),
+                                        new Post(
+                                                PostId.of("1"),
+                                                PostTitle.of("원글"),
+                                                PostAuthor.of("원글쓴이"),
+                                                MultilineText.of("원글 내용")),
+                                        CommentAuthor.of("종희"),
+                                        MultilineText.of("반갑습니다!! 잘 이용할게요.")
+                                )
+                        )
+                );
+
+        List<CommentDto> commentDtos = getCommentsService.getComments("1");
+
+        assertThat(commentDtos.size()).isEqualTo(2);
+        assertThat(commentDtos.get(0).getAuthor()).contains("케이");
+        assertThat(commentDtos.get(1).getContent()).contains("반갑습니다");
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/application/GetPostServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/GetPostServiceTest.java
@@ -1,0 +1,64 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetPostServiceTest {
+
+    private PostRepository postRepository;
+
+    private GetPostService getPostService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+
+        getPostService = new GetPostService(postRepository);
+    }
+
+    @Test
+    @DisplayName("게시물 조회")
+    void detail() {
+        given(postRepository.findById(PostId.of("1")))
+                .willReturn(
+                        Optional.of(new Post(
+                                PostId.of("1"),
+                                PostTitle.of("공지사항입니다."),
+                                PostAuthor.of("관리자"),
+                                MultilineText.of("안녕하세요.\n자유게시판 이용 부탁드립니다.\n"))));
+        given(postRepository.findById(PostId.of("2")))
+                .willReturn(
+                        Optional.of(new Post(
+                                PostId.of("2"),
+                                PostTitle.of("내가 첫 글???"),
+                                PostAuthor.of("김종희"),
+                                MultilineText.of("신난닷!!\n너무 좋아용~~!!"))));
+
+        PostDto postDto = getPostService.getPost("2");
+        assertThat(postDto).isNotNull();
+        assertThat(postDto.getAuthor()).contains("종희");
+        assertThat(postDto.getContent()).contains("좋아용");
+
+        postDto = getPostService.getPost("1");
+        assertThat(postDto).isNotNull();
+        assertThat(postDto.getTitle()).contains("공지사항");
+
+        assertThrows(PostNotFound.class, () -> getPostService.getPost("3"));
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/application/GetPostsServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/GetPostsServiceTest.java
@@ -1,0 +1,55 @@
+package kr.megaptera.assignment.application;
+
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetPostsServiceTest {
+
+    private PostRepository postRepository;
+
+    private GetPostsService getPostsService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        getPostsService = new GetPostsService(postRepository);
+    }
+
+    @Test
+    @DisplayName("게시물 목록 조회")
+    void list() {
+        given(postRepository.findAll())
+                .willReturn(
+                        List.of(
+                                new Post(
+                                        PostId.of("1"),
+                                        PostTitle.of("공지사항입니다."),
+                                        PostAuthor.of("관리자"),
+                                        MultilineText.of("안녕하세요.\n자유게시판 이용 부탁드립니다.\n")),
+                                new Post(
+                                        PostId.of("2"),
+                                        PostTitle.of("내가 첫 글???"),
+                                        PostAuthor.of("김종희"),
+                                        MultilineText.of("신난닷!!\n너무 좋아용~~!!"))));
+
+        List<PostDto> postDtos = getPostsService.getPosts();
+
+        assertThat(postDtos.size()).isEqualTo(2);
+        assertThat(postDtos.get(0).getTitle()).contains("공지사항");
+        assertThat(postDtos.get(1).getContent()).contains("!!");
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/application/UpdateCommentServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/UpdateCommentServiceTest.java
@@ -1,0 +1,67 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentAuthor;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.exceptions.CommentNotFound;
+import kr.megaptera.assignment.repositories.CommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class UpdateCommentServiceTest {
+
+    private CommentRepository commentRepository;
+
+    private UpdateCommentService updateCommentService;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        updateCommentService = new UpdateCommentService(commentRepository);
+    }
+
+    @Test
+    @DisplayName("게시물에 이미 존재하는 댓글 수정")
+    void updateComment() {
+        given(commentRepository.findById(CommentId.of("3")))
+                .willReturn(
+                        Optional.of(new Comment(
+                                CommentId.of("3"),
+                                new Post(
+                                        PostId.of("1"),
+                                        PostTitle.of("원글"),
+                                        PostAuthor.of("원글쓴이"),
+                                        MultilineText.of("원글 내용")),
+                                CommentAuthor.of("케이"),
+                                MultilineText.of("감사합니다!\n운영자님")
+                        ))
+                );
+
+        CommentUpdateDto commentUpdateDto = new CommentUpdateDto("아차, 수정하겠습니다.\n또 만나요~");
+        CommentDto commentDto = updateCommentService.updateComment("3", "1", commentUpdateDto);
+
+        verify(commentRepository).save(any(Comment.class));
+        assertThat(commentDto.getContent()).contains("수정하겠습니다");
+        assertThrows(CommentNotFound.class, () -> updateCommentService.updateComment("4", "1", commentUpdateDto));
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/application/UpdatePostServiceTest.java
+++ b/src/test/java/kr/megaptera/assignment/application/UpdatePostServiceTest.java
@@ -1,0 +1,59 @@
+package kr.megaptera.assignment.application;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import kr.megaptera.assignment.repositories.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+class UpdatePostServiceTest {
+
+    private PostRepository postRepository;
+
+    private UpdatePostService updatePostService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        updatePostService = new UpdatePostService(postRepository);
+    }
+
+    @Test
+    @DisplayName("게시물 수정")
+    void update() {
+        given(postRepository.findById(PostId.of("2")))
+                .willReturn(
+                        Optional.of(new Post(
+                                PostId.of("2"),
+                                PostTitle.of("내가 첫 글???"),
+                                PostAuthor.of("김종희"),
+                                MultilineText.of("신난닷!!\n너무 좋아용~~!!"))));
+
+        PostUpdateDto postUpdateDto = new PostUpdateDto("새로 글 쓰기", "새로 글을\n쓰는 중입니다.\n\n좋아용");
+
+        PostDto postDto = updatePostService.updatePost("2", postUpdateDto);
+
+        verify(postRepository).save(any(Post.class));
+        assertThat(postDto).isNotNull();
+        assertThat(postDto.getTitle()).contains("새로");
+        assertThrows(PostNotFound.class, () -> updatePostService.updatePost("3", postUpdateDto));
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/controllers/CommentControllerTest.java
+++ b/src/test/java/kr/megaptera/assignment/controllers/CommentControllerTest.java
@@ -1,0 +1,124 @@
+package kr.megaptera.assignment.controllers;
+
+import kr.megaptera.assignment.application.CreateCommentService;
+import kr.megaptera.assignment.application.DeleteCommentService;
+import kr.megaptera.assignment.application.GetCommentsService;
+import kr.megaptera.assignment.application.UpdateCommentService;
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.dto.CommentDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest {
+    // TODO: CommentControllerTest 를 참고해서 테스트를 작성해 주세요.
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    GetCommentsService getCommentsService;
+    @MockBean
+    CreateCommentService createCommentService;
+    @MockBean
+    UpdateCommentService updateCommentService;
+    @MockBean
+    DeleteCommentService deleteCommentService;
+
+
+    @Test
+    @DisplayName("GET /comments?postId={postId}  - with correct post ID")
+    void list() throws Exception {
+        given(getCommentsService.getComments("2"))
+                .willReturn(
+                        List.of(
+                                new CommentDto("1", "관리자", "안녕하세요.\n자유게시판 이용 부탁드립니다.\n"),
+                                new CommentDto("2", "김종희", "신난닷!!\n너무 좋아용~~!!")));
+
+        mockMvc.perform(get("/comments?postId=2"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content()
+                        .string(containsString("자유게시판")))
+                .andExpect(MockMvcResultMatchers.content()
+                        .string(containsString("김종희")));
+    }
+
+    @Test
+    @DisplayName("GET /Comments?postId={postId} - If the post has no comments")
+    void listWithNoComment() throws Exception {
+        given(getCommentsService.getComments("2"))
+                .willReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/comments?postId=2"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /comments?postId={postId}")
+    void create() throws Exception {
+        String json = """
+                {
+                    "author": "케이",
+                    "content": "하하하!"
+                }
+                """;
+
+        mockMvc.perform(post("/comments?postId=2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
+
+        verify(createCommentService).createComment(any(String.class), any(CommentCreateDto.class));
+    }
+
+    @Test
+    @DisplayName("PATCH /Comments/{id}?postId={postId}")
+    void update() throws Exception {
+        given(updateCommentService.updateComment("1", "3", new CommentUpdateDto("하하하!")))
+                .willReturn(new CommentDto("1", "관리자", "하하하!"));
+
+        String json = """
+                {
+                    "content": "하하하!"
+                }
+                """;
+
+        mockMvc.perform(patch("/comments/1?postId=3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+
+        verify(updateCommentService).updateComment(any(String.class), any(String.class), any(CommentUpdateDto.class));
+    }
+
+    @Test
+    @DisplayName("DELETE /Comments/{id}?postId={postId}")
+    void deleteComment() throws Exception {
+        given(deleteCommentService.deleteComment("1"))
+                .willReturn(new CommentDto("1", "관리자", "하하하!"));
+
+        mockMvc.perform(delete("/comments/1?postId=3")).andExpect(status().isOk());
+
+        verify(deleteCommentService).deleteComment(any(String.class));
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/assignment/controllers/PostControllerTest.java
@@ -1,0 +1,139 @@
+package kr.megaptera.assignment.controllers;
+
+import kr.megaptera.assignment.application.CreatePostService;
+import kr.megaptera.assignment.application.DeletePostService;
+import kr.megaptera.assignment.application.GetPostService;
+import kr.megaptera.assignment.application.GetPostsService;
+import kr.megaptera.assignment.application.UpdatePostService;
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.dto.PostDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+import kr.megaptera.assignment.exceptions.PostNotFound;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    GetPostService getPostService;
+    @MockBean
+    GetPostsService getPostsService;
+    @MockBean
+    CreatePostService createPostService;
+    @MockBean
+    UpdatePostService updatePostService;
+    @MockBean
+    DeletePostService deletePostService;
+
+    @Test
+    @DisplayName("GET /posts")
+    void list() throws Exception {
+        given(getPostsService.getPosts())
+                .willReturn(
+                        List.of(
+                                new PostDto("1", "공지사항입니다.", "관리자", "안녕하세요.\n자유게시판 이용 부탁드립니다.\n"),
+                                new PostDto("2", "내가 첫 글???", "김종희", "신난닷!!\n너무 좋아용~~!!")));
+
+        mockMvc.perform(get("/posts"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content()
+                        .string(containsString("공지사항")));
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id} - with correct ID")
+    void detailWithCorrectId() throws Exception {
+        given(getPostService.getPost("1"))
+                .willReturn(new PostDto("1", "공지사항입니다.", "관리자", "안녕하세요.\n자유게시판 이용 부탁드립니다.\n"));
+
+        mockMvc.perform(get("/posts/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content()
+                        .string(containsString("관리자")));
+
+
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id} - with incorrect ID")
+    void detail() throws Exception {
+        given(getPostService.getPost("2"))
+                .willThrow(new PostNotFound());
+
+        mockMvc.perform(get("/posts/2"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /posts")
+    void create() throws Exception {
+        String json = """
+                {
+                    "author": "케이",
+                    "title": "새 글",
+                    "content": "하하하!"
+                }
+                """;
+
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
+
+        verify(createPostService).createPost(any(PostCreateDto.class));
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{id}")
+    void update() throws Exception {
+        given(updatePostService.updatePost("1", new PostUpdateDto("새 글", "하하하!")))
+                .willReturn(new PostDto("1", "새 글", "관리자", "하하하!"));
+
+        String json = """
+                {
+                    "title": "새 글",
+                    "content": "하하하!"
+                }
+                """;
+
+        mockMvc.perform(patch("/posts/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+
+        verify(updatePostService).updatePost(any(String.class), any(PostUpdateDto.class));
+    }
+
+    @Test
+    @DisplayName("DELETE /posts/{id}")
+    void deletePost() throws Exception {
+        given(deletePostService.deletePost("1"))
+                .willReturn(new PostDto("1", "새 글", "관리자", "하하하!"));
+
+        mockMvc.perform(delete("/posts/1")).andExpect(status().isOk());
+
+        verify(deletePostService).deletePost(any(String.class));
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/model/CommentIdTest.java
+++ b/src/test/java/kr/megaptera/assignment/model/CommentIdTest.java
@@ -1,0 +1,23 @@
+package kr.megaptera.assignment.model;
+
+import kr.megaptera.assignment.domains.model.CommentId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentIdTest {
+
+    @Test
+    void creation() {
+        CommentId commentId1 = new CommentId();
+        CommentId commentId2 = new CommentId();
+        CommentId commentId3 = new CommentId("3");
+
+        assertThat(commentId1.getId()).isNotNull();
+        assertThat(commentId2.getId()).isNotNull();
+        assertThat(commentId1.getId()).isNotEqualTo(commentId2.getId());
+        assertThat(commentId2.getId()).isGreaterThan(commentId1.getId());
+        assertThat(commentId3.getId()).contains("3");
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/model/CommentTest.java
+++ b/src/test/java/kr/megaptera/assignment/model/CommentTest.java
@@ -1,0 +1,55 @@
+package kr.megaptera.assignment.model;
+
+import jakarta.transaction.Transactional;
+import kr.megaptera.assignment.domains.dto.CommentCreateDto;
+import kr.megaptera.assignment.domains.dto.CommentUpdateDto;
+import kr.megaptera.assignment.domains.model.Comment;
+import kr.megaptera.assignment.domains.model.CommentId;
+import kr.megaptera.assignment.domains.model.MultilineText;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostAuthor;
+import kr.megaptera.assignment.domains.model.PostId;
+import kr.megaptera.assignment.domains.model.PostTitle;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class CommentTest {
+
+    @Test
+    void creation() {
+        CommentCreateDto CommentCreateDto = new CommentCreateDto("글쓴이입니다", "내용입니다\n\n내용");
+        Comment Comment = new Comment(
+                new Post(
+                        PostId.of("3"),
+                        PostTitle.of("원글"),
+                        PostAuthor.of("원글쓴이"),
+                        MultilineText.of("원글 내용")), CommentCreateDto);
+
+        assertThat(Comment.id()).isNotNull();
+        assertThat(Comment.post().id().getId()).contains("3");
+        assertThat(Comment.author().getAuthor()).contains("글쓴이");
+        assertThat(Comment.content().toString()).contains("내용");
+    }
+
+    @Test
+    void updateComment() {
+        CommentCreateDto CommentCreateDto = new CommentCreateDto("글쓴이입니다", "내용입니다\n\n내용");
+        Comment Comment = new Comment(
+                new Post(
+                        PostId.of("3"),
+                        PostTitle.of("원글"),
+                        PostAuthor.of("원글쓴이"),
+                        MultilineText.of("원글 내용")), CommentCreateDto);
+        CommentId CommentId = Comment.id();
+
+        CommentUpdateDto CommentUpdateDto = new CommentUpdateDto("새로운 내용~입니닷");
+        Comment.updateComment(CommentUpdateDto);
+
+        assertThat(Comment.id().getId()).isEqualTo(CommentId.getId());
+        assertThat(Comment.post().id().getId()).contains("3");
+        assertThat(Comment.author().getAuthor()).contains("글쓴이");
+        assertThat(Comment.content().toString()).contains("~입니닷");
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/model/MultilineTextTest.java
+++ b/src/test/java/kr/megaptera/assignment/model/MultilineTextTest.java
@@ -1,0 +1,27 @@
+package kr.megaptera.assignment.model;
+
+import kr.megaptera.assignment.domains.model.MultilineText;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MultilineTextTest {
+
+    @Test
+    void Creation() {
+        MultilineText text = new MultilineText("안녕하세요~\n다들 반갑습니다^^\n\n다들 식사는 하셨나요?\n");
+        assertThat(text).isNotNull();
+        assertThat(text).hasFieldOrProperty("content");
+        assertThat(text.getContent().size()).isEqualTo(4);
+    }
+
+    @Test
+    void testToString() {
+        String start = "안녕하세요~\n다들 반갑습니다^^\n\n다들 식사는 하셨나요?";
+        MultilineText text = new MultilineText(start);
+        assertThat(text).isNotNull();
+
+        String textString = text.toString();
+        assertThat(textString).isEqualTo(start.trim());
+    }
+}

--- a/src/test/java/kr/megaptera/assignment/model/PostIdTest.java
+++ b/src/test/java/kr/megaptera/assignment/model/PostIdTest.java
@@ -1,0 +1,23 @@
+package kr.megaptera.assignment.model;
+
+import kr.megaptera.assignment.domains.model.PostId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostIdTest {
+
+    @Test
+    void creation() {
+        PostId postId1 = new PostId();
+        PostId postId2 = new PostId();
+        PostId postId3 = new PostId("3");
+
+        assertThat(postId1.getId()).isNotNull();
+        assertThat(postId2.getId()).isNotNull();
+        assertThat(postId1.getId()).isNotEqualTo(postId2.getId());
+        assertThat(postId2.getId()).isGreaterThan(postId1.getId());
+        assertThat(postId3.getId()).contains("3");
+    }
+
+}

--- a/src/test/java/kr/megaptera/assignment/model/PostTest.java
+++ b/src/test/java/kr/megaptera/assignment/model/PostTest.java
@@ -1,0 +1,38 @@
+package kr.megaptera.assignment.model;
+
+import kr.megaptera.assignment.domains.dto.PostCreateDto;
+import kr.megaptera.assignment.domains.dto.PostUpdateDto;
+import kr.megaptera.assignment.domains.model.Post;
+import kr.megaptera.assignment.domains.model.PostId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostTest {
+
+    @Test
+    void creation() {
+        PostCreateDto postCreateDto = new PostCreateDto("제목입니다", "글쓴이입니다", "내용입니다\n\n내용");
+        Post post = new Post(postCreateDto);
+
+        assertThat(post.id()).isNotNull();
+        assertThat(post.title().getTitle()).contains("제목");
+        assertThat(post.author().getAuthor()).contains("글쓴이");
+        assertThat(post.content().toString()).contains("내용");
+    }
+
+    @Test
+    void updatePost() {
+        PostCreateDto postCreateDto = new PostCreateDto("제목입니다", "글쓴이입니다", "내용입니다\n\n내용");
+        Post post = new Post(postCreateDto);
+        PostId postId = post.id();
+
+        PostUpdateDto postUpdateDto = new PostUpdateDto("새로운 제목입니다", "새로운 내용~입니닷");
+        post.updatePost(postUpdateDto);
+
+        assertThat(post.id().getId()).isEqualTo(postId.getId());
+        assertThat(post.title().getTitle()).contains("새로운");
+        assertThat(post.author().getAuthor()).contains("글쓴이");
+        assertThat(post.content().toString()).contains("~입니닷");
+    }
+}


### PR DESCRIPTION
## 새롭게 배운 점
* @ActiveProfiles("test")는 소중하다.
* JPA를 사용할 때는 domain model 관련 class에는 모두 빈 생성자(parameter 0인 경우)의 정의가 필요하다. @Entity건 @Embeddable이건 상관 없다.
* Comment의 postId field를 Post 테이블을 아예 join해 주면서 @ManyToOne, @JoinColumn 하여 연결하였다.


## 어려웠던 점
* 예전에 프로젝트를 했었을 때는 @Embeddable을 사용하지 않았어서 이번 과제를 수행하며 다채롭게 단계별 에러를 경험하였다.
* Id 역할을 하는 객체들을 다루는 것이 까다로웠다. @EmbeddedId라는 annotation을 써주니 에러가 자꾸 생겨서, PostId와 CommentId의 id field에 @Column(insertable = false, updatable = false)라는 annotation을 추가하였다. 이렇게 하니 Id 중복 생성을 막을 수 있었다.
* 구조가 바뀔 때마다(DAO -> JPA 등) 테스트 코드도 계속 바꾸어 주어야 하고 생각보다 손이 많이 갔다.